### PR TITLE
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-H0uNAt/psycopg2/

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ virtualenv venv-foo
 . ./venv-foo/bin/activate
 pip install -r requirements.txt
 
-Ubuntu/Debia
-pip install前先使用sudo apt-get install libpq-dev python-dev
+Ubuntu/Debian
+use `sudo apt-get install libpq-dev python-dev` before `pip install -r requirements.txt`
 ```
 ## 使用：
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ cd flask_blog
 virtualenv venv-foo
 . ./venv-foo/bin/activate
 pip install -r requirements.txt
+××Ubuntu/Debia××
+××pip install前先使用sudo apt-get install libpq-dev python-dev××
 ```
 ## 使用：
 ```

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ cd flask_blog
 virtualenv venv-foo
 . ./venv-foo/bin/activate
 pip install -r requirements.txt
-××Ubuntu/Debia××
-××pip install前先使用sudo apt-get install libpq-dev python-dev××
+
+Ubuntu/Debia
+pip install前先使用sudo apt-get install libpq-dev python-dev
 ```
 ## 使用：
 ```


### PR DESCRIPTION
Something wrong when I use it in Ubuntu 16.04 64, I found that I can't install psycopg2.
